### PR TITLE
fix(tags): properly escape double quotes

### DIFF
--- a/src/tags/tags.toml
+++ b/src/tags/tags.toml
@@ -305,7 +305,7 @@ And anywhere in your scripts in package.json where you use `*` you should wrap i
 For example:
 ```json
 {
-	"format": "prettier --write \"src/**/*.ts\""
+	"format": "prettier --write \\"src/**/*.ts\\""
 }
 ```
 Mind you this last thing is good add regardless of script runner / package bundler because it ensures the glob is performed by the library and not by your shell, which may differ when people develop on different operating systems.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/65814829/186649938-39d45100-c89d-4ba7-b3c8-8531617a373b.png)

This is showing on Discord, so I assume you have to escape the quotes once more for the backslash to be visible.