### PR TITLE
feat(tags): change zeyr's repo url

### DIFF
--- a/src/tags/tags.toml
+++ b/src/tags/tags.toml
@@ -33,7 +33,7 @@ _ _
 - **[Radon ᴱ ᴬ](<https://github.com/EvolutionX-10/Radon>)**
 - **[Sapphire Application Commands Examples ᴱ](<https://github.com/vladfrangu/sapphire-application-commands-examples>)**
 - **[Archangel ᴱ ᴰ](<https://github.com/favware/archangel>)**
-- **[Zeyr ᴰ ᴬ](<https://github.com/brxem/zeyr>)**
+- **[Zeyr ᴰ ᴬ](<https://github.com/zeyrbot/zeyr>)**
 - **[Birthdayy ᴰ](<https://github.com/BirthdayyBot/BirthdayyBotSapphire>)**
 - **[KBot ᴱ ᴬ ᴰ](<https://github.com/KBot-discord/KBot>)**
 _ _


### PR DESCRIPTION
tldr: zeyr uses docker in production, check v2 branch